### PR TITLE
Generate better vcd names

### DIFF
--- a/valentyusb/usbcore/cpu/unififo.py
+++ b/valentyusb/usbcore/cpu/unififo.py
@@ -184,7 +184,7 @@ class TestUsbUniFifo(CommonUsbTestCase):
         print("-"*10)
         run_simulation(
             self.dut, padfront(),
-            vcd_name="vcd/%s.vcd" % self.id(),
+            vcd_name=self.make_vcd_name(),
             clocks={"sys": 4, "usb_48": 4, "usb_12": 16},
         )
         #    clocks={"usb_48": 4, "sys": 4})

--- a/valentyusb/usbcore/rx/bitstuff.py
+++ b/valentyusb/usbcore/rx/bitstuff.py
@@ -201,8 +201,7 @@ class TestRxBitstuffRemover(BaseUsbTestCase):
                 dut = RxBitstuffRemover()
 
                 run_simulation(dut, stim(**vector),
-                    vcd_name=self.make_vcd_name(
-                        basename="usbcore.rx.bitstuff.%d" % i))
+                    vcd_name=self.make_vcd_name(testsuffix=str(i)))
                 i += 1
 
 

--- a/valentyusb/usbcore/rx/bitstuff.py
+++ b/valentyusb/usbcore/rx/bitstuff.py
@@ -3,6 +3,7 @@
 from migen import *
 from migen.fhdl.decorators import ResetInserter
 
+from ..test.common import BaseUsbTestCase
 import unittest
 
 
@@ -83,7 +84,7 @@ class RxBitstuffRemover(Module):
         ]
 
 
-class TestRxBitstuffRemover(unittest.TestCase):
+class TestRxBitstuffRemover(BaseUsbTestCase):
     def test_bitstuff(self):
         def set_input(dut, r, v):
             yield dut.reset.eq(r == '1')
@@ -199,7 +200,9 @@ class TestRxBitstuffRemover(unittest.TestCase):
             with self.subTest(i=i, vector=vector):
                 dut = RxBitstuffRemover()
 
-                run_simulation(dut, stim(**vector), vcd_name="vcd/test_bitstuff_%d.vcd" % i)
+                run_simulation(dut, stim(**vector),
+                    vcd_name=self.make_vcd_name(
+                        basename="usbcore.rx.bitstuff.%d" % i))
                 i += 1
 
 

--- a/valentyusb/usbcore/rx/clock.py
+++ b/valentyusb/usbcore/rx/clock.py
@@ -3,6 +3,7 @@
 from migen import *
 from migen.genlib import cdc
 
+from ..test.common import BaseUsbTestCase
 import unittest
 
 
@@ -156,7 +157,7 @@ class RxClockDataRecovery(Module):
 
 
 
-class TestRxClockDataRecovery(unittest.TestCase):
+class TestRxClockDataRecovery(BaseUsbTestCase):
     def test_basic_recovery(self):
         """
         This test covers basic clock and data recovery.
@@ -214,7 +215,9 @@ class TestRxClockDataRecovery(unittest.TestCase):
 
                 dut = RxClockDataRecovery(usbp_raw, usbn_raw)
 
-                run_simulation(dut, stim(), vcd_name="vcd/test_basic_recovery_%s.vcd" % seq)
+                run_simulation(dut, stim(),
+                    vcd_name=self.make_vcd_name(
+                        basename="usbcore.rx.clock.basic_recovery_%s" % seq))
 
 
         long_test_sequences = [
@@ -230,7 +233,10 @@ class TestRxClockDataRecovery(unittest.TestCase):
 
                     dut = RxClockDataRecovery(usbp_raw, usbn_raw)
 
-                    run_simulation(dut, stim(glitch), vcd_name="vcd/test_basic_recovery_%s_%d.vcd" % (seq, glitch))
+                    run_simulation(dut, stim(glitch),
+                        vcd_name=self.make_vcd_name(
+                            basename="usbcore.rx.clock.basic_recovery_" +
+                                     "%s_%d" % (seq, glitch)))
 
 
 if __name__ == "__main__":

--- a/valentyusb/usbcore/rx/clock.py
+++ b/valentyusb/usbcore/rx/clock.py
@@ -217,7 +217,7 @@ class TestRxClockDataRecovery(BaseUsbTestCase):
 
                 run_simulation(dut, stim(),
                     vcd_name=self.make_vcd_name(
-                        basename="usbcore.rx.clock.basic_recovery_%s" % seq))
+                        testsuffix="clock.basic_recovery_%s" % seq))
 
 
         long_test_sequences = [
@@ -235,7 +235,7 @@ class TestRxClockDataRecovery(BaseUsbTestCase):
 
                     run_simulation(dut, stim(glitch),
                         vcd_name=self.make_vcd_name(
-                            basename="usbcore.rx.clock.basic_recovery_" +
+                            testsuffix="basic_recovery_" +
                                      "%s_%d" % (seq, glitch)))
 
 

--- a/valentyusb/usbcore/rx/crc.py
+++ b/valentyusb/usbcore/rx/crc.py
@@ -3,6 +3,7 @@
 from migen import *
 from migen.fhdl.decorators import ResetInserter
 
+from ..test.common import BaseUsbTestCase
 import unittest
 
 
@@ -84,7 +85,7 @@ class RxCrcChecker(Module):
         ]
 
 
-class TestRxCrcChecker(unittest.TestCase):
+class TestRxCrcChecker(BaseUsbTestCase):
     def test_shifter(self):
         def send(reset, valid, value):
             crc_good = ""
@@ -222,7 +223,9 @@ class TestRxCrcChecker(unittest.TestCase):
                     i_data,
                     i_reset)
 
-                run_simulation(dut, stim(**vector), vcd_name="vcd/test_crc_%d.vcd" % i)
+                run_simulation(dut, stim(**vector),
+                    vcd_name=self.make_vcd_name(
+                        basename="usbcore.rx.crc.%d" % i))
 
 
 if __name__ == "__main__":

--- a/valentyusb/usbcore/rx/crc.py
+++ b/valentyusb/usbcore/rx/crc.py
@@ -224,8 +224,7 @@ class TestRxCrcChecker(BaseUsbTestCase):
                     i_reset)
 
                 run_simulation(dut, stim(**vector),
-                    vcd_name=self.make_vcd_name(
-                        basename="usbcore.rx.crc.%d" % i))
+                    vcd_name=self.make_vcd_name(testsuffix=str(i)))
 
 
 if __name__ == "__main__":

--- a/valentyusb/usbcore/rx/detect.py
+++ b/valentyusb/usbcore/rx/detect.py
@@ -5,6 +5,7 @@ from migen.genlib import cdc
 
 from migen.fhdl.decorators import ResetInserter
 
+from ..test.common import BaseUsbTestCase
 import unittest
 
 
@@ -90,7 +91,7 @@ class RxPacketDetect(Module):
         ]
 
 
-class TestRxPacketDetect(unittest.TestCase):
+class TestRxPacketDetect(BaseUsbTestCase):
     def test_packet_detect(self):
 
         test_vectors = [
@@ -177,7 +178,9 @@ class TestRxPacketDetect(unittest.TestCase):
             with self.subTest(i=i, vector=vector):
                 dut = RxPacketDetect()
 
-                run_simulation(dut, stim(**vector), vcd_name="vcd/test_packet_det_%d.vcd" % i)
+                run_simulation(dut, stim(**vector),
+                    vcd_name=self.make_vcd_name(
+                        basename="usbcore.rx.detect.%d" % i))
                 i += 1
 
 

--- a/valentyusb/usbcore/rx/detect.py
+++ b/valentyusb/usbcore/rx/detect.py
@@ -179,8 +179,7 @@ class TestRxPacketDetect(BaseUsbTestCase):
                 dut = RxPacketDetect()
 
                 run_simulation(dut, stim(**vector),
-                    vcd_name=self.make_vcd_name(
-                        basename="usbcore.rx.detect.%d" % i))
+                    vcd_name=self.make_vcd_name(testsuffix=str(i)))
                 i += 1
 
 

--- a/valentyusb/usbcore/rx/nrzi.py
+++ b/valentyusb/usbcore/rx/nrzi.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 from migen import *
+from ..test.common import BaseUsbTestCase
 
 import unittest
 
@@ -110,7 +111,7 @@ class RxNRZIDecoder(Module):
         ]
 
 
-class TestRxNRZIDecoder(unittest.TestCase):
+class TestRxNRZIDecoder(BaseUsbTestCase):
     def test_nrzi(self):
 
         def send(valid, value):
@@ -207,7 +208,9 @@ class TestRxNRZIDecoder(unittest.TestCase):
             with self.subTest(i=i, vector=vector):
                 dut = RxNRZIDecoder()
 
-                run_simulation(dut, stim(**vector), vcd_name="vcd/test_nrzi_%d.vcd" % i)
+                run_simulation(dut, stim(**vector),
+                    vcd_name=self.make_vcd_name(
+                        basename="usbcore.rx.nrzi.%d" % i))
                 i += 1
 
 

--- a/valentyusb/usbcore/rx/nrzi.py
+++ b/valentyusb/usbcore/rx/nrzi.py
@@ -209,8 +209,7 @@ class TestRxNRZIDecoder(BaseUsbTestCase):
                 dut = RxNRZIDecoder()
 
                 run_simulation(dut, stim(**vector),
-                    vcd_name=self.make_vcd_name(
-                        basename="usbcore.rx.nrzi.%d" % i))
+                    vcd_name=self.make_vcd_name(testsuffix=str(i)))
                 i += 1
 
 

--- a/valentyusb/usbcore/rx/pipeline.py
+++ b/valentyusb/usbcore/rx/pipeline.py
@@ -263,8 +263,7 @@ class TestRxPipeline(BaseUsbTestCase):
                 dut = RxPipeline()
                 run_simulation(
                     dut, stim(**vector),
-                    vcd_name=self.make_vcd_name(
-                        basename="usbcore.rx.pipeline." + fname),
+                    vcd_name=self.make_vcd_name(testsuffix=fname),
                     clocks={"sys": 10, "usb_48": 40, "usb_12": 160},
                 )
 

--- a/valentyusb/usbcore/rx/pipeline.py
+++ b/valentyusb/usbcore/rx/pipeline.py
@@ -11,6 +11,7 @@ from .detect import RxPacketDetect
 from .nrzi import RxNRZIDecoder
 from .shifter import RxShifter
 from ..utils.packet import b, nrzi
+from ..test.common import BaseUsbTestCase
 
 
 class RxPipeline(Module):
@@ -93,7 +94,7 @@ class RxPipeline(Module):
 
 
 
-class TestRxPipeline(unittest.TestCase):
+class TestRxPipeline(BaseUsbTestCase):
     def test_pkt_decode(self):
 
         test_vectors = {
@@ -262,7 +263,8 @@ class TestRxPipeline(unittest.TestCase):
                 dut = RxPipeline()
                 run_simulation(
                     dut, stim(**vector),
-                    vcd_name="vcd/test_decode_%s.vcd" % fname,
+                    vcd_name=self.make_vcd_name(
+                        basename="usbcore.rx.pipeline." + fname),
                     clocks={"sys": 10, "usb_48": 40, "usb_12": 160},
                 )
 

--- a/valentyusb/usbcore/rx/shifter.py
+++ b/valentyusb/usbcore/rx/shifter.py
@@ -2,6 +2,7 @@
 
 from migen import *
 from migen.fhdl.decorators import CEInserter, ResetInserter
+from ..test.common import BaseUsbTestCase
 
 import unittest
 
@@ -60,7 +61,7 @@ class RxShifter(Module):
         ]
 
 
-class TestRxShifter(unittest.TestCase):
+class TestRxShifter(BaseUsbTestCase):
     def test_shifter(self):
         test_vectors = [
             # 0
@@ -174,7 +175,8 @@ class TestRxShifter(unittest.TestCase):
                 dut = RxShifter(8)
 
                 actual_output.clear()
-                run_simulation(dut, send(**vector), vcd_name="vcd/test_shifter_%d.vcd" % i)
+                run_simulation(dut, send(**vector),
+                    vcd_name=self.make_vcd_name("usbcore.rx.shifter.%d" % i))
                 self.assertListEqual(vector['output'], actual_output)
 
 

--- a/valentyusb/usbcore/sm/header.py
+++ b/valentyusb/usbcore/sm/header.py
@@ -10,6 +10,7 @@ from ..pid import PIDTypes
 from ..rx.pipeline import RxPipeline
 from ..tx.pipeline import TxPipeline
 from ..utils.packet import *
+from ..test.common import BaseUsbTestCase
 
 
 class PacketHeaderDecode(Module):
@@ -61,7 +62,7 @@ class PacketHeaderDecode(Module):
         )
 
 
-class TestPacketHeaderDecode(unittest.TestCase):
+class TestPacketHeaderDecode(BaseUsbTestCase):
 
     def sim(self, stim):
         rx = RxPipeline()
@@ -69,7 +70,7 @@ class TestPacketHeaderDecode(unittest.TestCase):
 
         run_simulation(
             dut, stim(dut),
-            vcd_name="vcd/test_token_decode_%s.vcd" % self.id(),
+            vcd_name=self.make_vcd_name(),
             clocks={"sys": 12, "usb_48": 48, "usb_12": 192},
         )
 

--- a/valentyusb/usbcore/sm/send.py
+++ b/valentyusb/usbcore/sm/send.py
@@ -12,6 +12,7 @@ from ..tx.crc import TxParallelCrcGenerator
 from ..utils.asserts import assertMultiLineEqualSideBySide
 from ..utils.packet import *
 from ..utils.pprint import pp_packet
+from ..test.common import BaseUsbTestCase
 
 
 class TxPacketSend(Module):
@@ -125,7 +126,7 @@ class TxPacketSend(Module):
         fsm.act('ERROR')
 
 
-class CommonTxPacketSendTestCase:
+class CommonTxPacketSendTestCase(BaseUsbTestCase):
     maxDiff=None
 
     def assert_packet_sent(self, dut, pid, data=None, ndata=None):
@@ -293,7 +294,7 @@ class TestTxPacketSendNoCrc(CommonTxPacketSendTestCase, unittest.TestCase):
 
         run_simulation(
             dut, stim(dut),
-            vcd_name="vcd/test_token_decode_%s.vcd" % self.id(),
+            vcd_name=self.make_vcd_name(),
             clocks={"sys": 10, "usb_48": 40, "usb_12": 160},
         )
 
@@ -315,7 +316,7 @@ class TestTxPacketSendAutoCrc(CommonTxPacketSendTestCase, unittest.TestCase):
 
         run_simulation(
             dut, stim(dut),
-            vcd_name="vcd/test_token_decode_%s.vcd" % self.id(),
+            vcd_name=self.make_vcd_name(),
             clocks={"sys": 10, "usb_48": 40, "usb_12": 160},
         )
 

--- a/valentyusb/usbcore/sm/transaction.py
+++ b/valentyusb/usbcore/sm/transaction.py
@@ -351,7 +351,7 @@ class TestUsbTransaction(CommonUsbTestCase, CommonTestMultiClockDomain):
         print("-"*10)
         run_simulation(
             self.dut, padfront(),
-            vcd_name="vcd/%s.vcd" % self.id(),
+            vcd_name=self.make_vcd_name(),
             clocks={"sys": 12, "usb_48": 48, "usb_12": 192},
         )
         print("-"*10)

--- a/valentyusb/usbcore/test/common.py
+++ b/valentyusb/usbcore/test/common.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 
 import unittest
+import inspect
 
 from itertools import zip_longest
+from migen import run_simulation as run_migen_simulation
 
 from ..endpoint import *
 from ..pid import *
@@ -20,8 +22,29 @@ def grouper(n, iterable, pad=None):
     """
     return zip_longest(*[iter(iterable)]*n, fillvalue=pad)
 
+# Test case helpers common to all test cases, simple and complex
+#
+class BaseUsbTestCase(unittest.TestCase):
+    # Create a name for the vcd file based on the test case module/class/method
+    def make_vcd_name(self, basename=None, modulename=None):
+        if not basename:
+            basename = self.id()
 
-class CommonUsbTestCase(unittest.TestCase):
+            # Automagically guess caller's module if not defined and
+            # unittest.TestCase is finding __main__ as top level
+            if basename.startswith('__main__') and not modulename:
+                caller = inspect.stack()[1]
+                module = inspect.getmodule(caller[0])
+                modulename = module.__spec__.name
+
+            if modulename:
+                basename = basename.replace('__main__', modulename)
+
+        return ("vcd/%s.vcd" % basename)
+
+# Test case helper class for more complex test cases
+#
+class CommonUsbTestCase(BaseUsbTestCase):
     maxDiff=None
 
     def assertMultiLineEqualSideBySide(self, data1, data2, msg):

--- a/valentyusb/usbcore/test/common.py
+++ b/valentyusb/usbcore/test/common.py
@@ -4,7 +4,6 @@ import unittest
 import inspect
 
 from itertools import zip_longest
-from migen import run_simulation as run_migen_simulation
 
 from ..endpoint import *
 from ..pid import *
@@ -22,11 +21,15 @@ def grouper(n, iterable, pad=None):
     """
     return zip_longest(*[iter(iterable)]*n, fillvalue=pad)
 
-# Test case helpers common to all test cases, simple and complex
-#
 class BaseUsbTestCase(unittest.TestCase):
-    # Create a name for the vcd file based on the test case module/class/method
+    """
+    Test case helpers common to all test cases, simple and complex
+    """
     def make_vcd_name(self, basename=None, modulename=None):
+        """
+        Create a name for the vcd file based on the test case
+        module/class/method
+        """
         if not basename:
             basename = self.id()
 

--- a/valentyusb/usbcore/test/common.py
+++ b/valentyusb/usbcore/test/common.py
@@ -25,10 +25,10 @@ class BaseUsbTestCase(unittest.TestCase):
     """
     Test case helpers common to all test cases, simple and complex
     """
-    def make_vcd_name(self, basename=None, modulename=None):
+    def make_vcd_name(self, basename=None, modulename=None, testsuffix=None):
         """
         Create a name for the vcd file based on the test case
-        module/class/method
+        module/class/method, with optional testsuffix (eg, foo.N)
         """
         if not basename:
             basename = self.id()
@@ -43,7 +43,10 @@ class BaseUsbTestCase(unittest.TestCase):
             if modulename:
                 basename = basename.replace('__main__', modulename)
 
-        return ("vcd/%s.vcd" % basename)
+        if testsuffix:
+            return ("vcd/%s.%s.vcd" % (basename, testsuffix))
+        else:
+            return ("vcd/%s.vcd" % basename)
 
 # Test case helper class for more complex test cases
 #

--- a/valentyusb/usbcore/tx/crc.py
+++ b/valentyusb/usbcore/tx/crc.py
@@ -12,6 +12,7 @@ from ..utils.CrcMoose3 import CrcAlgorithm
 from ..utils.packet import crc5, crc16, encode_data, b
 from .shifter import TxShifter
 from .tester import module_tester
+from ..test.common import BaseUsbTestCase
 
 
 @CEInserter()
@@ -95,7 +96,7 @@ class TxSerialCrcGenerator(Module):
 
     o_crc       = ("width",)
 )
-class TestTxSerialCrcGenerator(unittest.TestCase):
+class TestTxSerialCrcGenerator(BaseUsbTestCase):
     def test_token_crc5_zeroes(self):
         self.do(
             width      = 5,
@@ -432,7 +433,7 @@ def o(d):
     return v
 
 
-class TestTxParallelCrcGenerator(unittest.TestCase):
+class TestTxParallelCrcGenerator(BaseUsbTestCase):
     def sim(self, name, dut, in_data, expected_crc):
         def stim():
             yield dut.i_data_strobe.eq(1)
@@ -446,7 +447,7 @@ class TestTxParallelCrcGenerator(unittest.TestCase):
             print("{0} {1:04x} {1:016b} {2:04x} {2:016b}".format(name, expected_crc, o_crc))
             self.assertEqual(hex(expected_crc), hex(o_crc))
 
-        run_simulation(dut, stim(), vcd_name="vcd/test_crc_parallel_%s.vcd" % self.id())
+        run_simulation(dut, stim(), vcd_name=self.make_vcd_name())
 
     def sim_crc16(self, in_data):
         expected_crc = o(crc16(in_data))
@@ -528,7 +529,7 @@ class TxCrcPipeline(Module):
         ]
 
 
-class TestCrcPipeline(unittest.TestCase):
+class TestCrcPipeline(BaseUsbTestCase):
     maxDiff=None
 
     def sim(self, data):
@@ -566,7 +567,7 @@ class TestCrcPipeline(unittest.TestCase):
                 yield
             self.assertLess(i, MAX)
 
-        run_simulation(dut, stim(), vcd_name="vcd/test_crc_pipeline_%s.vcd" % self.id())
+        run_simulation(dut, stim(), vcd_name=self.make_vcd_name())
 
     def test_00000001_byte(self):
         self.sim([0b00000001])

--- a/valentyusb/usbcore/tx/pipeline.py
+++ b/valentyusb/usbcore/tx/pipeline.py
@@ -295,8 +295,7 @@ class TestTxPipeline(BaseUsbTestCase):
                 fname = name.replace(" ","_")
                 dut = TxPipeline()
                 run_simulation(dut, stim(**vector),
-                    vcd_name=self.make_vcd_name(
-                        basename="usbcore.tx.pipeline." + fname),
+                    vcd_name=self.make_vcd_name(testsuffix=fname),
                     clocks={"sys": 10, "usb_48": 40, "usb_12": 160})
 
 

--- a/valentyusb/usbcore/tx/pipeline.py
+++ b/valentyusb/usbcore/tx/pipeline.py
@@ -9,6 +9,7 @@ from .bitstuff import TxBitstuffer
 from .nrzi import TxNRZIEncoder
 from .shifter import TxShifter
 from ..utils.packet import b, nrzi, diff
+from ..test.common import BaseUsbTestCase
 
 
 class TxPipeline(Module):
@@ -94,7 +95,7 @@ class TxPipeline(Module):
 
 
 
-class TestTxPipeline(unittest.TestCase):
+class TestTxPipeline(BaseUsbTestCase):
     maxDiff=None
 
     def test_pkt_decode(self):
@@ -293,7 +294,10 @@ class TestTxPipeline(unittest.TestCase):
             with self.subTest(name=name):
                 fname = name.replace(" ","_")
                 dut = TxPipeline()
-                run_simulation(dut, stim(**vector), vcd_name="vcd/test_pipeline_%s.vcd" % fname, clocks={"sys": 10, "usb_48": 40, "usb_12": 160})
+                run_simulation(dut, stim(**vector),
+                    vcd_name=self.make_vcd_name(
+                        basename="usbcore.tx.pipeline." + fname),
+                    clocks={"sys": 10, "usb_48": 40, "usb_12": 160})
 
 
 if __name__ == "__main__":

--- a/valentyusb/usbcore/tx/shifter.py
+++ b/valentyusb/usbcore/tx/shifter.py
@@ -193,8 +193,7 @@ class TestTxShifter(BaseUsbTestCase):
                 dut = TxShifter(vector["width"])
 
                 run_simulation(dut, stim(**vector),
-                    vcd_name=self.make_vcd_name(
-                        basename="usbcore.tx.shifter." + fname))
+                    vcd_name=self.make_vcd_name(testsuffix=fname))
 
 
 if __name__ == "__main__":

--- a/valentyusb/usbcore/tx/shifter.py
+++ b/valentyusb/usbcore/tx/shifter.py
@@ -7,6 +7,7 @@ from migen import *
 from migen.fhdl.decorators import CEInserter, ResetInserter
 
 from ..utils.packet import b
+from ..test.common import BaseUsbTestCase
 
 
 @ResetInserter()
@@ -68,7 +69,7 @@ class TxShifter(Module):
         ]
 
 
-class TestTxShifter(unittest.TestCase):
+class TestTxShifter(BaseUsbTestCase):
     def test_shifter(self):
         test_vectors = {
             "basic shift out 1": dict(
@@ -191,7 +192,9 @@ class TestTxShifter(unittest.TestCase):
                 fname = name.replace(' ', '_')
                 dut = TxShifter(vector["width"])
 
-                run_simulation(dut, stim(**vector), vcd_name="vcd/test_tx_shifter_%s.vcd" % fname)
+                run_simulation(dut, stim(**vector),
+                    vcd_name=self.make_vcd_name(
+                        basename="usbcore.tx.shifter." + fname))
 
 
 if __name__ == "__main__":

--- a/valentyusb/usbcore/tx/tester.py
+++ b/valentyusb/usbcore/tx/tester.py
@@ -6,10 +6,11 @@ from migen import *
 
 MIGEN_SIGNALS = ("reset", "ce")
 
-# Helper to find the ultimate caller's module name (extra level further up
-# stack than case where test directly inherits from BaseUsbTestCase).
-#
 def get_ultimate_caller_modulename():
+    """
+    Helper to find the ultimate caller's module name (extra level further up
+    stack than case where test directly inherits from BaseUsbTestCase).
+    """
     caller = inspect.stack()[2]
     module = inspect.getmodule(caller[0])
     return module.__spec__.name

--- a/valentyusb/usbcore/tx/tester.py
+++ b/valentyusb/usbcore/tx/tester.py
@@ -1,12 +1,24 @@
 #!/usr/bin/env python3
 
+import inspect
+
 from migen import *
 
 MIGEN_SIGNALS = ("reset", "ce")
 
+# Helper to find the ultimate caller's module name (extra level further up
+# stack than case where test directly inherits from BaseUsbTestCase).
+#
+def get_ultimate_caller_modulename():
+    caller = inspect.stack()[2]
+    module = inspect.getmodule(caller[0])
+    return module.__spec__.name
+
 def create_tester(dut_type, **def_args):
     def run(self, **test_args):
         name = self.id()
+        self.vcd_name = self.make_vcd_name(
+            modulename=get_ultimate_caller_modulename())
 
         self.inputs = dict()
         self.outputs = dict()
@@ -118,7 +130,7 @@ def create_tester(dut_type, **def_args):
 
 
         # run simulation
-        run_simulation(dut, stim(), vcd_name="vcd/%s.vcd" % name)
+        run_simulation(dut, stim(), vcd_name=self.vcd_name)
 
         return actual_output
 


### PR DESCRIPTION
Adds a `BaseUsbTestCase` class between `CommonUsbTestCase` and `unittest.TestCase` with a `make_vcd_name` function that generates the full path to the vcd file (rather than repeating that in lots of places).   Attempts to avoid using `__main__` in the file name by replacing it with `__spec__.name` instead (ie, `foo.bar.baz` module name).

So far only `usbcore/sm` has been switched over (other than `usbcore/sm/test.py` which AFAICT isn't runable), but if you're happy with the approach I'll convert over the ones I can find in `usbcore/tx`, `usbcore/rx`, etc.

Ewen

PS: Example filenames created:

```
(LX P=tinyfpga_bx.minimal F=micropython) ewen@parthenon:/src/fpga/litex-buildenv
/third_party/usb-bootloader/valentyusb$ ls vcd
README.md
usbcore.sm.send.TestTxPacketSendAutoCrc.test_ack.vcd
usbcore.sm.send.TestTxPacketSendAutoCrc.test_data0_all_zero.vcd
usbcore.sm.send.TestTxPacketSendAutoCrc.test_data0_descriptor.vcd
usbcore.sm.send.TestTxPacketSendAutoCrc.test_data0_edges.vcd
usbcore.sm.send.TestTxPacketSendAutoCrc.test_data0_one_one.vcd
usbcore.sm.send.TestTxPacketSendAutoCrc.test_data0_one_zero.vcd
usbcore.sm.send.TestTxPacketSendAutoCrc.test_data0_two_ones.vcd
usbcore.sm.send.TestTxPacketSendAutoCrc.test_data1_all_zero.vcd
usbcore.sm.send.TestTxPacketSendAutoCrc.test_nak.vcd
usbcore.sm.send.TestTxPacketSendAutoCrc.test_stall.vcd
usbcore.sm.send.TestTxPacketSendAutoCrc.test_status0.vcd
usbcore.sm.send.TestTxPacketSendAutoCrc.test_status1.vcd
usbcore.sm.send.TestTxPacketSendNoCrc.test_ack.vcd
usbcore.sm.send.TestTxPacketSendNoCrc.test_data0_all_zero.vcd
usbcore.sm.send.TestTxPacketSendNoCrc.test_data0_descriptor.vcd
usbcore.sm.send.TestTxPacketSendNoCrc.test_data0_edges.vcd
usbcore.sm.send.TestTxPacketSendNoCrc.test_data0_one_one.vcd
usbcore.sm.send.TestTxPacketSendNoCrc.test_data0_one_zero.vcd
usbcore.sm.send.TestTxPacketSendNoCrc.test_data0_two_ones.vcd
usbcore.sm.send.TestTxPacketSendNoCrc.test_data1_all_zero.vcd
usbcore.sm.send.TestTxPacketSendNoCrc.test_nak.vcd
usbcore.sm.send.TestTxPacketSendNoCrc.test_stall.vcd
usbcore.sm.send.TestTxPacketSendNoCrc.test_status0.vcd
usbcore.sm.send.TestTxPacketSendNoCrc.test_status1.vcd
(LX P=tinyfpga_bx.minimal F=micropython) ewen@parthenon:/src/fpga/litex-buildenv
/third_party/usb-bootloader/valentyusb$ 
```